### PR TITLE
bugfix/22360_Monitor_shows_hostname_instead_of_sensor_name_with_redborder-proxy_sensor

### DIFF
--- a/resources/libraries/update_manager_config.rb
+++ b/resources/libraries/update_manager_config.rb
@@ -186,7 +186,7 @@ module Rbmonitor
         node.default['redborder']['monitor']['count'] = node.default['redborder']['monitor']['count'] + 1
       end
 
-      sensor_name = if node['redborder']['ips'] && !node['redborder']['cloud']
+      sensor_name = if node['redborder']['is_proxy'] || (node['redborder']['ips'] && !node['redborder']['cloud'])
                       node['rbname']
                     else
                       resource['hostname']

--- a/resources/libraries/update_manager_config.rb
+++ b/resources/libraries/update_manager_config.rb
@@ -186,15 +186,9 @@ module Rbmonitor
         node.default['redborder']['monitor']['count'] = node.default['redborder']['monitor']['count'] + 1
       end
 
-      sensor_name = if node['redborder']['is_proxy'] || (node['redborder']['ips'] && !node['redborder']['cloud'])
-                      node['rbname']
-                    else
-                      resource['hostname']
-                    end
-
       manager_sensor = {
         'timeout' => 5,
-        'sensor_name' => sensor_name,
+        'sensor_name' => node['rbname'] || resource['hostname'],
         'sensor_ip' => resource['hostip'],
         'community' => resource['community'],
         'snmp_version' => '2c',


### PR DESCRIPTION
## Related issue in RedMine

[Bug #22360 Monitor shows hostname instead of sensor_name with redborder-proxy sensor](https://redmine.redborder.lan/issues/22360)

## Description / Motivation

Monitor shows hostname instead of sensor_name with redborder-proxy sensor

## Detail

Related with [[https://github.com/redBorder/cookbook-rb-monitor/pull/20]] Fix name of ips
